### PR TITLE
fix: Add pandas-ta to requirements

### DIFF
--- a/V4-D.8(v7.0)/data_acquisition/requirements.txt
+++ b/V4-D.8(v7.0)/data_acquisition/requirements.txt
@@ -2,3 +2,4 @@ yfinance
 pandas
 pyarrow
 fastparquet
+pandas-ta


### PR DESCRIPTION
Adds the `pandas-ta` dependency to `requirements.txt` to resolve the `ModuleNotFoundError`.