### PR TITLE
fix: Pin dependencies to resolve conflict

### DIFF
--- a/V4-D.8(v7.0)/data_acquisition/requirements.txt
+++ b/V4-D.8(v7.0)/data_acquisition/requirements.txt
@@ -2,4 +2,5 @@ yfinance
 pandas
 pyarrow
 fastparquet
-pandas-ta
+pandas-ta==0.4.71b0
+numpy==2.2.6


### PR DESCRIPTION
Pins the versions of `pandas-ta` and `numpy` in `requirements.txt` to create a reproducible environment. This addresses the dependency conflict between `tensorflow` and `pandas-ta`.