### PR TITLE
Bug(02_build_features): 修復 BBWidth 計算與索引合併錯誤

### DIFF
--- a/V4-D.8(v7.0)/ml_pipeline/02_build_features.py
+++ b/V4-D.8(v7.0)/ml_pipeline/02_build_features.py
@@ -103,8 +103,8 @@ def calculate_base_metrics(data_60m):
 
         try:
             bbands = ta.bbands(group['Close'], length=20)
-            if isinstance(bbands, pd.DataFrame) and all(c in bbands.columns for c in ['BBU_20_2.0', 'BBL_20_2.0', 'BBM_20_2.0']):
-                group['BBWidth_20_60m'] = (bbands['BBU_20_2.0'] - bbands['BBL_20_2.0']) / bbands['BBM_20_2.0']
+            if isinstance(bbands, pd.DataFrame) and all(c in bbands.columns for c in ['BBU_20_2.0_2.0', 'BBL_20_2.0_2.0', 'BBM_20_2.0_2.0']):
+                group['BBWidth_20_60m'] = (bbands['BBU_20_2.0_2.0'] - bbands['BBL_20_2.0_2.0']) / bbands['BBM_20_2.0_2.0']
             else:
                 group['BBWidth_20_60m'] = np.nan
         except Exception as e:
@@ -326,6 +326,9 @@ def build_features():
     # Combine features
     # Merge A, B, and C which are already daily
     features_abc = features_a.join(features_b, how='outer').join(features_c, how='outer')
+
+    # --- FIX: Rename index to match features_g_shifted before joining ---
+    features_abc.index.names = ['asset', 'T-1_timestamp']
 
     # Shift G features to align with T-1 timestamp
     features_g_shifted = features_g.groupby(level='symbol').shift(1)


### PR DESCRIPTION
此提交包含兩項主要的修復：

1.  **修復 BBWidth 特徵計算**： 在 `calculate_base_metrics` 函數中，`pandas-ta` 的 `ta.bbands()` 函數回傳的欄位名稱包含了額外的 `_2.0` 後綴，導致原有的欄位名稱檢查失敗。此變更將 `if` 條件式和計算公式中硬式編碼的欄位名稱更新為正確的格式（例如 `BBU_20_2.0_2.0`），以確保 `BBWidth` 特徵能夠被正確計算。

2.  **修復索引合併錯誤**： 在 `build_features` 函數中，合併 `features_abc` 和 `features_g_shifted` 兩個 DataFrame 時，由於索引欄位名稱不一致，導致 `ValueError: cannot join with no overlapping index names` 錯誤。此變更在合併前，將 `features_abc` 的索引欄位名稱重新命名為與 `features_g_shifted` 一致的 `['asset', 'T-1_timestamp']`，以解決此問題。